### PR TITLE
Update entrypoint.sh to use new output method

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,4 +10,8 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
-echo "::set-output name=golint-output::Golint step succeed"
+if [ -z "${GITHUB_OUTPUT}" ]; then
+  echo "::set-output name=golint-output::Golint step succeed"
+else
+  echo "golint-output=Golint step succeed" >> "${GITHUB_OUTPUT}"
+fi


### PR DESCRIPTION
This fixes the following warning that is currently produced by this action:

```
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands
```